### PR TITLE
CASMPET-5501: Match on BOS Operator pods

### DIFF
--- a/charts/kyverno-policies/Chart.yaml
+++ b/charts/kyverno-policies/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kyverno-policy
-version: 1.0.0
+version: 1.2.0
 appVersion: v1.6.0
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policies/templates/pod-sec-ctxt-cray-bos.yaml
+++ b/charts/kyverno-policies/templates/pod-sec-ctxt-cray-bos.yaml
@@ -24,7 +24,6 @@ spec:
         selector:
           matchLabels:
             app.kubernetes.io/instance: cray-bos
-            app.kubernetes.io/name: cray-bos
     mutate:
       foreach:
       - list: "request.object.spec.containers"

--- a/charts/kyverno-policies/templates/validation/validate-pod-sec-ctxt-cray-bos.yaml
+++ b/charts/kyverno-policies/templates/validation/validate-pod-sec-ctxt-cray-bos.yaml
@@ -26,7 +26,6 @@ spec:
         selector:
           matchLabels:
             app.kubernetes.io/instance: cray-bos
-            app.kubernetes.io/name: cray-bos
     validate:
       message: >-
         Running as root is not allowed, Privilege escalation is disallowed and Privileged mode is disallowed. The fields


### PR DESCRIPTION
## Summary and Scope

Loosen the matching criteria, so that it matches on the BOS operator
pods, too, not just the BOS API server pods. This improves the security
coverage by extending the security context mutations to additional BOS
pods.

## Issues and Related PRs

_List and characterize relationship to Jira/Github issues and other pull requests. Be sure to list dependencies._

* Resolves CASMPET-5501

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * Mug

### Test description:

I made this policy change. I then deleted the BOS V2 pods and some them restart with the security context added. Then, I tested that the BOS V2 micro-service functioned correctly while under these new security mutations. I ran through the entire BOS V2 happy path testing.

- Were the install/upgrade-based validation checks/tests run (goss tests/install-validation doc)? Nope.
- Were continuous integration tests run? If not, why? No, because we don't have any.
- Was upgrade tested? No, it was a policy change.
- Was downgrade tested? No, it was a policy change.
- Were new tests (or test issues/Jiras) created for this change? No.

## Risks and Mitigations

Low. We're expanding our security coverage surface.


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [x] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

