### PR TITLE
CASMPET-6455: Remove new logic that breaks chart meta

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,22 +42,7 @@ COMMA := ,
 
 all: chart
 
-chart: chart-metadata chart-package chart-test
-
-chart-metadata:
-	docker run --rm \
-		--user $(shell id -u):$(shell id -g) \
-		-v ${PWD}/${CHARTDIR}/${NAME}:/chart \
-		${CHART_METADATA_IMAGE} \
-		--version "${CHART_VERSION}" --app-version "${VERSION}" \
-		-i ${NAME} ${IMAGE}:${VERSION} \
-		--cray-service-globals
-	docker run --rm \
-		--user $(shell id -u):$(shell id -g) \
-		-v ${PWD}/${CHARTDIR}/${NAME}:/chart \
-		-w /chart \
-		${YQ_IMAGE} \
-		eval -Pi '.cray-service.containers.${NAME}.image.repository = "${IMAGE}"' values.yaml
+chart: chart-package chart-test
 
 helm:
 	docker run --rm \
@@ -80,12 +65,6 @@ packages/${NAME}-${CHART_VERSION}.tgz:
 chart-test:
 	CMD="lint ${CHARTDIR}/${NAME}" $(MAKE) helm
 	docker run --rm -v ${PWD}/${CHARTDIR}:/apps ${HELM_UNITTEST_IMAGE} ${NAME}
-
-chart-images: packages/${NAME}-${CHART_VERSION}.tgz
-	{ CMD="template release $< --dry-run --replace --dependency-update" $(MAKE) -s helm; \
-	  echo '---' ; \
-	  CMD="show chart $<" $(MAKE) -s helm | docker run --rm -i $(YQ_IMAGE) e -N '.annotations."artifacthub.io/images"' - ; \
-	} | docker run --rm -i $(YQ_IMAGE) e -N '.. | .image? | select(.)' - | sort -u
 
 snyk:
 	$(MAKE) -s chart-images | xargs --verbose -n 1 snyk container test

--- a/charts/kyverno-policy/Chart.yaml
+++ b/charts/kyverno-policy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kyverno-policy
-version: 1.3.0
+version: 1.3.1
 appVersion: v1.6.0
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:


### PR DESCRIPTION
Address build breaking issue related to partial 'image' annotations in chart metadata. 