### PR TITLE
CASMPET-6455: Remove new logic that breaks chart meta

### DIFF
--- a/charts/kyverno-policy/Chart.yaml
+++ b/charts/kyverno-policy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kyverno-policy
-version: 1.4.0
+version: 1.4.1
 appVersion: v1.6.0
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:


### PR DESCRIPTION
Address build breaking issue related to partial 'image' annotations in chart metadata.