### PR TITLE
Exclude wait-for jobs from auto three day cleanup (CASMINST-6453)

### DIFF
--- a/charts/kyverno-policy/Chart.yaml
+++ b/charts/kyverno-policy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kyverno-policy
-version: 1.4.1
+version: 1.4.2
 appVersion: v1.6.0
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policy/templates/cluster/cluster-job-ttl.yaml
+++ b/charts/kyverno-policy/templates/cluster/cluster-job-ttl.yaml
@@ -12,6 +12,11 @@ metadata:
 spec:
   rules:
     - name: cluster-job-ttl
+      exclude:
+        all:
+        - resources:
+            names:
+            - "*-wait-for-*"
       match:
         resources:
           kinds:


### PR DESCRIPTION
### Summary and Scope

Exclude wait-for jobs from auto three day cleanup


### Issues and Related PRs

* https://jira-pro.it.hpe.com:8443/browse/CASMINST-6453

### Testing

Drax:

```
cray-bss-567f949774-46q6t                                         2/2     Running            0          3h7m
cray-bss-567f949774-dxbtt                                         2/2     Running            0          32m
cray-bss-567f949774-xvk2t                                         2/2     Running            0          3h20m
```

```
ncn-m001:~ # kubectl get job -n services cray-bss-wait-for-etcd-3 -o yaml | grep ttl
ncn-m001:~ #
```

Was a fresh Install tested? N
Was an Upgrade tested?      N - N/A
Was a Downgrade tested?     N - N/A
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

### Risks and Mitigations

Low

### Requires:

* Nothing
