### PR TITLE
CASMCMS-8290: Add a Kyverno mutating policy for VCS

### DIFF
--- a/charts/kyverno-policy/Chart.yaml
+++ b/charts/kyverno-policy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kyverno-policy
-version: 1.4.2
+version: 1.4.3
 appVersion: v1.6.0
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policy/templates/security/pod-sec-ctxt-gitea.yaml
+++ b/charts/kyverno-policy/templates/security/pod-sec-ctxt-gitea.yaml
@@ -1,0 +1,38 @@
+{{- $name := "pod-sec-ctxt-gitea" }}
+{{- include "kyverno-policy.supportedKyvernoCheck" (dict "top" . "ver" ">= 1.6.0-0") }}
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: {{ $name }}
+  namespace: services
+  annotations:
+    policies.kyverno.io/title: Require runAsNonRoot, disallow Privilege Escalation and Privileged Containers
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Containers must be required to run as non-root users. Privilege escalation, such as via set-user-ID
+      or set-group-ID file mode, should not be allowed. Privileged mode disables most security mechanisms
+      and must not be allowed. This policy ensures `runAsNonRoot` is set to `true`,
+      `allowPrivilegeEscalation` field is set to `false` and pods do not call for privileged mode.
+spec:
+  rules:
+  - name: set-container-security-context
+    match:
+      resources:
+        kinds:
+        - Pod
+        selector:
+          matchLabels:
+            app.kubernetes.io/instance: gitea
+            app.kubernetes.io/name: vcs
+    mutate:
+      foreach:
+      - list: "request.object.spec.containers"
+        patchStrategicMerge:
+          spec:
+            containers:
+            - (name): "*"
+              securityContext:
+                runAsNonRoot: true
+                allowPrivilegeEscalation: false
+                privileged: false

--- a/charts/kyverno-policy/templates/security/validation/validate-pod-sec-ctxt-gitea.yaml
+++ b/charts/kyverno-policy/templates/security/validation/validate-pod-sec-ctxt-gitea.yaml
@@ -1,0 +1,42 @@
+{{- $name := "validate-pod-sec-ctxt-gitea" }}
+{{- include "kyverno-policy.supportedKyvernoCheck" (dict "top" . "ver" ">= 1.6.0-0") }}
+apiVersion: kyverno.io/v1
+kind: Policy
+metadata:
+  name: {{ $name }}
+  namespace: services
+  annotations:
+    policies.kyverno.io/title: Require runAsNonRoot, disallow Privilege Escalation and Privileged Containers
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      Containers must be required to run as non-root users. Privilege escalation, such as via set-user-ID
+      or set-group-ID file mode, should not be allowed. Privileged mode disables most security mechanisms
+      and must not be allowed. This policy ensures `runAsNonRoot` is set to `true`, `allowPrivilegeEscalation`
+      field is set to `false` and pods do not call for privileged mode.
+spec:
+  background: true
+  validationFailureAction: audit
+  rules:
+  - name: container-security-context
+    match:
+      resources:
+        kinds:
+        - Pod
+        selector:
+          matchLabels:
+            app.kubernetes.io/instance: gitea
+            app.kubernetes.io/name: vcs
+    validate:
+      message: >-
+        Running as root is not allowed, Privilege escalation is disallowed and Privileged mode is disallowed. The fields
+        spec.containers[*].securityContext.runAsNonRoot must be set to `true`, spec.containers[*].securityContext.allowPrivilegeEscalation
+        must be set to `false` and spec.containers[*].securityContext.privileged must be unset or set to `false`.
+      pattern:
+        spec:
+          containers:
+          - (name): "*"
+            securityContext:
+              runAsNonRoot: true
+              allowPrivilegeEscalation: false
+              privileged: false


### PR DESCRIPTION
## Summary and Scope

Extend the current Kyverno mutation policy covering non-root and Privilege escalation to VCS Ingress service . This was part red team findings.

## Testing

Tested on Mug.
Policies are listed in the system:
ncn-m001:~ # kubectl get pol -A | grep -i gitea
services    pod-sec-ctxt-gitea                                  true         audit    true
services    validate-pod-sec-ctxt-gitea                         true         audit    true
ncn-m001:~ # 

### Tested on:

Mug

### Test description:
https://cray.slack.com/archives/C05CQ8BKRGQ/p1687445423166619