### PR TITLE
CASM-4670 CASM-4819 Image Signatures

### DIFF
--- a/charts/kyverno-policy/Chart.yaml
+++ b/charts/kyverno-policy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kyverno-policy
-version: 1.4.4
+version: 1.4.5
 appVersion: v1.6.0
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policy/Chart.yaml
+++ b/charts/kyverno-policy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kyverno-policy
-version: 1.4.5
+version: 1.6.0
 appVersion: v1.6.0
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policy/Chart.yaml
+++ b/charts/kyverno-policy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kyverno-policy
-version: 1.4.3
+version: 1.4.4
 appVersion: v1.6.0
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policy/templates/cluster/cluster-check-image.yaml
+++ b/charts/kyverno-policy/templates/cluster/cluster-check-image.yaml
@@ -1,3 +1,8 @@
+{{- $keys := .Values.checkImagePolicy.publicKeys }}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.k8sSecretName) }}
+{{- if $secret }}
+{{- $keys = $secret.data }}
+{{- end }}
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
@@ -5,7 +10,9 @@ metadata:
   annotations:
     policies.kyverno.io/title: Verify Cosign image signatures against provided public key
     policies.kyverno.io/description: >-
-      Verify Cosign image signatures against provided public key.
+      Verify Cosign image signatures against provided public key(s).
+    kyverno.io/kyverno-version: 1.6.0
+    policies.kyverno.io/subject: Pod
   name: check-image
 spec:
   validationFailureAction: {{ .Values.checkImagePolicy.validationFailureAction }}
@@ -18,19 +25,26 @@ spec:
       any:
       - resources:
           kinds:
-          - Pod
+            - Pod
+          namespaces:
+            - "*"
+    exclude:
+      any:
+        - resources:
+            namespaces:
+              - sample-ns
+            names:
+              - "sample-name"
     verifyImages:
     - imageReferences:
 {{ .Values.checkImagePolicy.imageReferences | toYaml | indent 6 }}
-      repository: {{ .Values.checkImagePolicy.repository }}
       mutateDigest: {{ .Values.checkImagePolicy.mutateDigest }}
       verifyDigest: {{ .Values.checkImagePolicy.verifyDigest }}
       attestors:
-{{- range .Values.checkImagePolicy.publicKeys }}
       - count: 1
         entries:
         - keys:
             publicKeys: |-
-{{ . | indent 14 }}
-            signatureAlgorithm: sha256
+{{- range $name, $key := $keys }}
+{{ $key | b64dec | trim | indent 14 }}
 {{- end }}

--- a/charts/kyverno-policy/templates/cluster/cluster-check-image.yaml
+++ b/charts/kyverno-policy/templates/cluster/cluster-check-image.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  annotations:
+    policies.kyverno.io/title: Verify Cosign image signatures against provided public key
+    policies.kyverno.io/description: >-
+      Verify Cosign image signatures against provided public key.
+  name: check-image
+spec:
+  validationFailureAction: {{ .Values.checkImagePolicy.validationFailureAction }}
+  background: {{ .Values.checkImagePolicy.background }}
+  webhookTimeoutSeconds: {{ .Values.checkImagePolicy.webhookTimeoutSeconds }}
+  failurePolicy: {{ .Values.checkImagePolicy.failurePolicy }}
+  rules:
+  - name: check-image
+    match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    verifyImages:
+    - imageReferences:
+{{ .Values.checkImagePolicy.imageReferences | toYaml | indent 6 }}
+      repository: {{ .Values.checkImagePolicy.repository }}
+      mutateDigest: {{ .Values.checkImagePolicy.mutateDigest }}
+      verifyDigest: {{ .Values.checkImagePolicy.verifyDigest }}
+      attestors:
+{{- range .Values.checkImagePolicy.publicKeys }}
+      - count: 1
+        entries:
+        - keys:
+            publicKeys: |-
+{{ . | indent 14 }}
+            signatureAlgorithm: sha256
+{{- end }}

--- a/charts/kyverno-policy/values.yaml
+++ b/charts/kyverno-policy/values.yaml
@@ -1,0 +1,12 @@
+---
+checkImagePolicy:
+  validationFailureAction: Audit
+  background: true
+  webhookTimeoutSeconds: 30
+  failurePolicy: Ignore
+  repository: registry.local
+  mutateDigest: false
+  verifyDigest: false
+  imageReferences:
+  - "*"
+  publicKeys: []

--- a/charts/kyverno-policy/values.yaml
+++ b/charts/kyverno-policy/values.yaml
@@ -3,10 +3,11 @@ checkImagePolicy:
   validationFailureAction: Audit
   background: true
   webhookTimeoutSeconds: 30
-  failurePolicy: Ignore
+  failurePolicy: Fail
   repository: registry.local
   mutateDigest: false
   verifyDigest: false
   imageReferences:
   - "*"
   publicKeys: []
+k8sSecretName: "hpe-oci-signing-key"


### PR DESCRIPTION
## Summary and Scope

_Summarize what has changed. Explain why this PR is necessary. What is impacted? Is this a new feature, critical bug fix, etc?_

Includes:
- [CASM-4670](https://jira-pro.it.hpe.com:8443/browse/CASM-4670)
- [CASM-4819](https://jira-pro.it.hpe.com:8443/browse/CASM-4819)

Adds a new `helm` template for a new kyverno policy for verifying images. The template reads keys from a Kubernetes secret created by: https://github.com/Cray-HPE/csm/pull/3596

## Testing

_List the environments in which these changes were tested._

### Tested on:

  * `surtur`

### Test description:

I only ran `helm template`, I did not run a `helm upgrade` or `helm install`.

1. Pulled this branch onto surtur
2. Created the `hpe-oci-signing-key` secret in the `kyverno` namespace
3. In the checked out branch's directory, I ran `helm template --validate --debug --dry-run=server --namespace kyverno kyverno-policy .`
4. This generated a valid template containing each key

During a `helm install` or `helm upgrade` the template will be generated all the same.

`helm template` outputs the keys in base64 as they appear in the K8s secret, but they are properly decoded during `helm upgrade`.

Tested `helm upgrade` on surtur and ran the following:

```bash
ncn-m001:~/rusty/kyverno-CASM-4819/cray-kyverno-policies/charts/kyverno-policy # kubectl run signed --image=registry.local/artifactory.algol60.net/csm-docker/stable/cray-bss-ipxe:1.12.1
pod/signed created
```

No "verification failed" errors were emitted.
