### PR TITLE
CASM-4855 Make image signature validation rules customizable

### DIFF
--- a/charts/kyverno-policy/Chart.yaml
+++ b/charts/kyverno-policy/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: kyverno-policy
-version: 1.6.0
-appVersion: v1.6.0
+version: 1.6.1
+appVersion: v1.6.1
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:
   - kubernetes

--- a/charts/kyverno-policy/templates/cluster/cluster-check-image.yaml
+++ b/charts/kyverno-policy/templates/cluster/cluster-check-image.yaml
@@ -1,8 +1,3 @@
-{{- $keys := .Values.checkImagePolicy.publicKeys }}
-{{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.k8sSecretName) }}
-{{- if $secret }}
-{{- $keys = $secret.data }}
-{{- end }}
 ---
 apiVersion: kyverno.io/v1
 kind: ClusterPolicy
@@ -11,40 +6,10 @@ metadata:
     policies.kyverno.io/title: Verify Cosign image signatures against provided public key
     policies.kyverno.io/description: >-
       Verify Cosign image signatures against provided public key(s).
-    kyverno.io/kyverno-version: 1.6.0
-    policies.kyverno.io/subject: Pod
   name: check-image
 spec:
   validationFailureAction: {{ .Values.checkImagePolicy.validationFailureAction }}
   background: {{ .Values.checkImagePolicy.background }}
   webhookTimeoutSeconds: {{ .Values.checkImagePolicy.webhookTimeoutSeconds }}
   failurePolicy: {{ .Values.checkImagePolicy.failurePolicy }}
-  rules:
-  - name: check-image
-    match:
-      any:
-      - resources:
-          kinds:
-            - Pod
-          namespaces:
-            - "*"
-    exclude:
-      any:
-        - resources:
-            namespaces:
-              - sample-ns
-            names:
-              - "sample-name"
-    verifyImages:
-    - imageReferences:
-{{ .Values.checkImagePolicy.imageReferences | toYaml | indent 6 }}
-      mutateDigest: {{ .Values.checkImagePolicy.mutateDigest }}
-      verifyDigest: {{ .Values.checkImagePolicy.verifyDigest }}
-      attestors:
-      - count: 1
-        entries:
-        - keys:
-            publicKeys: |-
-{{- range $name, $key := $keys }}
-{{ $key | b64dec | trim | indent 14 }}
-{{- end }}
+  rules: {{ .Values.checkImagePolicy.rules | toYaml | nindent 4 }}

--- a/charts/kyverno-policy/values.yaml
+++ b/charts/kyverno-policy/values.yaml
@@ -4,10 +4,47 @@ checkImagePolicy:
   background: true
   webhookTimeoutSeconds: 30
   failurePolicy: Fail
-  repository: registry.local
-  mutateDigest: false
-  verifyDigest: false
-  imageReferences:
-  - "*"
-  publicKeys: []
-k8sSecretName: "hpe-oci-signing-key"
+  #
+  # Image validation rules default to an empty list, and
+  # supposed to be overridden via customizations. Typical set of rules:
+  #
+  # rules:
+  #   - name: check-image
+  #     exclude:
+  #       any:
+  #       - resources:
+  #           names:
+  #           - sample-name
+  #           namespaces:
+  #           - sample-ns
+  #     match:
+  #       any:
+  #       - resources:
+  #           kinds:
+  #           - Pod
+  #           namespaces:
+  #           - '*'
+  #     verifyImages:
+  #     - imageReferences:
+  #       - '*'
+  #       repository: registry.local
+  #       mutateDigest: false
+  #       required: true
+  #       verifyDigest: false
+  #       attestors:
+  #       - count: 1
+  #         entries:
+  #         - keys:
+  #             signatureAlgorithm: sha256
+  #             publicKeys: |-
+  #               -----BEGIN PUBLIC KEY-----
+  #               ...
+  #               -----END PUBLIC KEY-----
+  #               -----BEGIN PUBLIC KEY-----
+  #               ...
+  #               -----END PUBLIC KEY-----
+  #
+  # Documentaion and samples can be found at:
+  # https://kyverno.io/docs/writing-policies/verify-images/sigstore/.
+  #
+  rules: []


### PR DESCRIPTION
## Summary and Scope

Image signature validation rules must be customizable. Customers may have their own keys (in addition to our keys) or even validation configs.  Standard way of tuning deployments with customer specific parameters is using [`customizations.yaml`](https://github.com/Cray-HPE/shasta-cfg/blob/release/1.6/customizations.yaml) file. It is used during fresh installs. During upgrades, existing configuration is preserved via k8s secret, and gets amended via [`update-customizations.sh`](https://github.com/Cray-HPE/docs-csm/blob/release/1.6/upgrade/scripts/upgrade/util/update-customizations.sh) script - this way we may alter configuration during future upgrades (for example, remove outdated keys).

This change also fixes misconfiguration which causes CASMTRIAGE-7287.

All PR's in this batch:
* https://github.com/Cray-HPE/shasta-cfg/pull/18
* https://github.com/Cray-HPE/csm/pull/3648
* https://github.com/Cray-HPE/cray-kyverno-policies/pull/14
* https://github.com/Cray-HPE/docs-csm/pull/5372

## Issues and Related PRs

* Resolves CASM-4855
* Resolves CASMTRIAGE-7287

## Testing
### Tested on:

  * Virtual Shasta

### Test description:

Deployed temporary build, ensured that check image policy is configured correctly.

## Risks and Mitigations

Low - we change the way things configured, but resulting configuration remains the same.
