### PR TITLE
CASMSEC-542: Add more exceptions for IUF Argo workflows

### DIFF
--- a/charts/kyverno-policy/Chart.yaml
+++ b/charts/kyverno-policy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kyverno-policy
-version: 1.7.6
+version: 1.7.7
 appVersion: v1.13.4
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policy/templates/exceptions/iuf-argo-exceptions.yaml
+++ b/charts/kyverno-policy/templates/exceptions/iuf-argo-exceptions.yaml
@@ -17,6 +17,7 @@ spec:
         - "*-pre-install-check-*-shell-script-*"
         - "*-deliver-product-*-shell-script-*"
         - "*-deliver-product-*-echo-message-*"
+        - "*-deploy-product-*-shell-script-*"
         - "*-process-media-*"
         namespaces:
         - argo
@@ -49,6 +50,7 @@ spec:
         - "*-deliver-product-*-nexus-docker-load-template-*"
         - "*-deliver-product-*-nexus-helm-load-template-*"
         - "*-deliver-product-*-nexus-rpm-load-template-*"
+        - "*-deliver-product-*-nexus-setup-template-*"
         namespaces:
         - argo
   podSecurity:
@@ -75,6 +77,7 @@ spec:
         names:
         - "*-prepare-images-*-shell-script-*"
         - "*-pre-install-check-*-shell-script-*"
+        - "*-deliver-product-*-shell-script-*"
         namespaces:
         - argo
   podSecurity:
@@ -102,6 +105,7 @@ spec:
         - "*-pre-install-check-*-shell-script-*"
         - "*-deliver-product-*-echo-message-*"
         - "*-deliver-product-*-shell-script-*"
+        - "*-deploy-product-*-shell-script-*"
         namespaces:
         - argo
   podSecurity:


### PR DESCRIPTION
## Summary and Scope

Policy Violations were seen in Wasp when a diags installed happened. Adding more conditions to the IUF argo exceptions to prevent the same.

## Issues and Related PRs

* Resolves CASMSEC-542

## Testing
### Tested on:

  * `wasp`

### Test description:
* No more violations were noticed after placing the exception.

## Risks and Mitigation


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

