### PR TITLE
CASMSEC-534: Prepending registry.local to container images is complicated

### DIFF
--- a/charts/kyverno-policy/Chart.yaml
+++ b/charts/kyverno-policy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kyverno-policy
-version: 1.7.6
+version: 1.7.7
 appVersion: v1.13.4
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policy/templates/cluster/cluster-check-image.yaml
+++ b/charts/kyverno-policy/templates/cluster/cluster-check-image.yaml
@@ -3,6 +3,7 @@ apiVersion: kyverno.io/v1
 kind: ClusterPolicy
 metadata:
   annotations:
+    pod-policies.kyverno.io/autogen-controllers: none
     policies.kyverno.io/title: Verify Cosign image signatures against provided public key
     policies.kyverno.io/description: >-
       Verify Cosign image signatures against provided public key(s).

--- a/charts/kyverno-policy/templates/cluster/cluster-prepend-registry.yaml
+++ b/charts/kyverno-policy/templates/cluster/cluster-prepend-registry.yaml
@@ -1,0 +1,75 @@
+apiVersion: kyverno.io/v1
+kind: ClusterPolicy
+metadata:
+  annotations:
+    pod-policies.kyverno.io/autogen-controllers: none
+    policies.kyverno.io/subject: Pod
+    policies.kyverno.io/description: >-
+      For CSM deployment, mirroring configuration is set into containerd via /etc/containerd/config.toml file.
+      In particular, this comfiguration rewrites images such as artifactory.algol60.net/csm-docker/name:tag
+      to be looked at in a registry named "registry.local" (i.e. instance of Nexus running locally in Kubernetes cluster).
+      This approach is not compatible with Kyverno check-image policy, which verifies image signatures. This policy
+      performs the same action (i.e. prepends "registry.local/" to image name), in a way compatible with Kyverno
+      check-image policy. Note: registry.local starts responding only after Nexus is deployed into Kubernetes cluster.
+      This policy can be deployed only when Nexus is already deployed and populated with content.
+  name: prepend-registry
+spec:
+  admission: true
+  background: true
+  emitWarning: false
+  rules:
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    mutate:
+      foreach:
+      - list: request.object.spec.containers
+        patchStrategicMerge:
+          spec:
+            containers:
+            - image: '{{ "{{" }} images.containers."{{ "{{" }} element.name {{ "}}" }}".registry != ''registry.local''
+                && ''registry.local/'' || '''' {{ "}}" }}{{ "{{" }} regex_replace_all(''^dtr.dev.cray.com/'',
+                ''{{ "{{" }} regex_replace_all(''^docker.io/'', ''{{ "{{" }}element.image{{ "}}" }}'', '''')
+                {{ "}}" }}'', '''') {{ "}}" }}'
+              name: "{{ "{{" }} element.name {{ "}}" }}"
+    name: prepend-registry-containers
+    preconditions:
+      all:
+      - key: "{{ "{{" }} request.operation || 'BACKGROUND' {{ "}}" }}"
+        operator: AnyIn
+        value:
+        - CREATE
+        - UPDATE
+    skipBackgroundRequests: true
+  - match:
+      any:
+      - resources:
+          kinds:
+          - Pod
+    mutate:
+      foreach:
+      - list: request.object.spec.initContainers
+        patchStrategicMerge:
+          spec:
+            initContainers:
+            - image: '{{ "{{" }} images.initContainers."{{ "{{" }} element.name {{ "}}" }}".registry != ''registry.local''
+                && ''registry.local/'' || '''' {{ "}}" }}{{ "{{" }} regex_replace_all(''^dtr.dev.cray.com/'',
+                ''{{ "{{" }} regex_replace_all(''^docker.io/'', ''{{ "{{" }}element.image{{ "}}" }}'', '''')
+                {{ "}}" }}'', '''') {{ "}}" }}'
+              name: "{{ "{{" }} element.name {{ "}}" }}"
+    name: prepend-registry-initcontainers
+    preconditions:
+      all:
+      - key: "{{ "{{" }} request.operation || 'BACKGROUND' {{ "}}" }}"
+        operator: AnyIn
+        value:
+        - CREATE
+        - UPDATE
+      - key: '{{ "{{" }} request.object.spec.initContainers[] || '''' | length(@) {{ "}}" }}'
+        operator: GreaterThanOrEquals
+        value: 1
+    skipBackgroundRequests: true
+  validationFailureAction: Audit
+

--- a/charts/kyverno-policy/templates/exceptions/check-image-exceptions.yaml
+++ b/charts/kyverno-policy/templates/exceptions/check-image-exceptions.yaml
@@ -1,0 +1,28 @@
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: check-image-exceptions
+  namespace: kyverno
+spec:
+  exceptions:
+  - policyName: check-image
+    ruleNames:
+    - check-image
+  match:
+    any:
+    - resources:
+        names:
+        - munge-vault-loader-*
+        namespaces:
+        - services
+    - resources:
+        kinds:
+        - Pod
+        names:
+        - pbs-*
+        - slurm-backup
+        - slurmctld-*
+        - slurmdb-*
+        - slurmdbd-*
+        namespaces:
+        - user

--- a/charts/kyverno-policy/templates/exceptions/prepend-registry-exception.yaml
+++ b/charts/kyverno-policy/templates/exceptions/prepend-registry-exception.yaml
@@ -1,0 +1,28 @@
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: prepend-registry-exceptions
+  namespace: kyverno
+spec:
+  exceptions:
+  - policyName: prepend-registry
+    ruleNames:
+    - prepend-registry-containers
+    - prepend-registry-initcontainers
+  match:
+    any:
+    - resources:
+        names:
+        - '*kea*'
+        - '*postgres*'
+        - '*nexus*'
+    - resources:
+        selector:
+          matchLabels:
+            spilo-role: '*'
+    - resources:
+        selector:
+          matchLabels:
+            prepend-registry: disable
+
+


### PR DESCRIPTION
## Summary and Scope

Added prepend-registry kyverno policy as a prerequisite for the check-image policy. Added exceptions for prepend-registry and check-image under exceptions folder. 

### Prerequisites
Is dependent on https://github.com/Cray-HPE/shasta-cfg/pull/25

## Testing
Upgrade and fresh install of the kyverno-chart changes were tested

### Tested on:
Starlord
### Test description:

[kyverno-policies-fresh-install.txt](https://github.com/user-attachments/files/19833129/kyverno-policies-fresh-install.txt)
[kyverno-policies-upgrade-logs.txt](https://github.com/user-attachments/files/19833130/kyverno-policies-upgrade-logs.txt)


