### PR TITLE
CASMSMF-8539 Fix Pod sma/opensearch-bootstrap-0 violates PodSecurity "baseline:latest" error

### DIFF
--- a/charts/kyverno-policy/Chart.yaml
+++ b/charts/kyverno-policy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kyverno-policy
-version: 1.7.7
+version: 1.7.8
 appVersion: v1.13.4
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policy/templates/exceptions/sma.yaml
+++ b/charts/kyverno-policy/templates/exceptions/sma.yaml
@@ -58,7 +58,7 @@ spec:
 apiVersion: kyverno.io/v2
 kind: PolicyException
 metadata:
-  name: sma-opensearch-masters
+  name: sma-opensearch
   namespace: {{ .Values.exceptions.namespace }}
 spec:
   exceptions:
@@ -76,10 +76,11 @@ spec:
         - sma
         names:
         - opensearch-masters*
+        - opensearch-bootstrap*
   podSecurity:
     - controlName: Privileged Containers
       images:
-        # Note: The pod has two init containers with this same
+        # Note: Both the pods have two init containers with this same
         # image and only one of them needs to be privileged,
         # but this is the only control we have to select to
         # which containers the exception applies.


### PR DESCRIPTION
## Summary and Scope

Logs from the kyverno-event-watcher-pod shows that the opensearch-bootstrap-0 pod violates podsecurity-subrule-baseline and was hence getting blocked.

~~~
2025-04-16T16:56:29Z | PV: N/A/podsecurity-subrule-baseline | Message: Pod sma/opensearch-bootstrap-0: [baseline] fail (blocked); Validation rule 'baseline' failed. It violates PodSecurity "baseline:latest": (Forbidden reason: privileged, field error list: [spec.initContainers[1].securityContext.privileged is forbidden, forbidden values found: true])
2025-04-16T16:59:13Z | PV: N/A/podsecurity-subrule-baseline | Message: Pod sma/opensearch-bootstrap-0: [baseline] fail (blocked); Validation rule 'baseline' failed. It violates PodSecurity "baseline:latest": (Forbidden reason: privileged, field error list: [spec.initContainers[1].securityContext.privileged is forbidden, forbidden values found: true])
2025-04-16T17:04:41Z | PV: N/A/podsecurity-subrule-baseline | Message: Pod sma/opensearch-bootstrap-0: [baseline] fail (blocked); Validation rule 'baseline' failed. It violates PodSecurity "baseline:latest": (Forbidden reason: privileged, field error list: [spec.initContainers[1].securityContext.privileged is forbidden, forbidden values found: true])
2025-04-16T17:15:36Z | PV: N/A/podsecurity-subrule-baseline | Message: Pod sma/opensearch-bootstrap-0: [baseline] fail (blocked); Validation rule 'baseline' failed. It violates PodSecurity "baseline:latest": (Forbidden reason: privileged, field error list: [spec.initContainers[1].securityContext.privileged is forbidden, forbidden values found: true])
2025-04-16T17:32:16Z | PV: N/A/podsecurity-subrule-baseline | Message: Pod sma/opensearch-bootstrap-0: [baseline] fail (blocked); Validation rule 'baseline' failed. It violates PodSecurity "baseline:latest": (Forbidden reason: privileged, field error list: [spec.initContainers[1].securityContext.privileged is forbidden, forbidden values found: true])
2025-04-16T17:48:56Z | PV: N/A/podsecurity-subrule-baseline | Message: Pod sma/opensearch-bootstrap-0: [baseline] fail (blocked); Validation rule 'baseline' failed. It violates PodSecurity "baseline:latest": (Forbidden reason: privileged, field error list: [spec.initContainers[1].securityContext.privileged is forbidden, forbidden values found: true]) 
~~~

This PR resolves this issue by extending the sma-opensearch-masters(renamed to sma-opensearch) policy exception to apply to opensearch-bootstrap pod. 

## Issues and Related PRs

* Resolves https://jira-pro.it.hpe.com:8443/browse/CASMSMF-8539

## Testing

### Tested on:

  * wasp - The image attached below shows the opensearch-bootstrap-0 pod running and then terminating as the master nodes are up. 
![image](https://github.com/user-attachments/assets/a527622d-febd-45b3-9b90-777f847f8fd1)

Terminal logs - [wasp_logs.txt](https://github.com/user-attachments/files/19843121/wasp_logs.txt)

## Pull Request Checklist

- [ ] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [ ] License file intact
- [ ] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

