### PR TITLE
CASMSEC-565: Add cray-hms-sls exception

### DIFF
--- a/charts/kyverno-policy/Chart.yaml
+++ b/charts/kyverno-policy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kyverno-policy
-version: 1.7.11
+version: 1.7.12
 appVersion: v1.13.4
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policy/templates/exceptions/cray-hms.yaml
+++ b/charts/kyverno-policy/templates/exceptions/cray-hms.yaml
@@ -1,0 +1,26 @@
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: cray-hms-sls
+  namespace: {{ .Values.exceptions.namespace }}
+spec:
+  exceptions:
+  - policyName: {{ .Values.exceptions.podSecurity.baseline.policyName }}
+    ruleNames:
+    - {{ .Values.exceptions.podSecurity.baseline.ruleName }}
+    - autogen-{{ .Values.exceptions.podSecurity.baseline.ruleName }}
+  match:
+    any:
+    - resources:
+        kinds:
+        - Pod
+        - Job
+        namespaces:
+        - services
+        names:
+        - cray-sls-init-load-nameserver-getter*
+  podSecurity:
+    - controlName: HostPath Volumes
+      restrictedField: spec.volumes[*].hostPath
+      values:
+        - /etc/


### PR DESCRIPTION
## Summary and Scope
As there was a job in cray-hms-sls that used a hostPath volume, I have issued an exception for cray-hms-sls. 

## Issues and Related PRs

* Resolves [CASMSEC-565](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-565)

## Testing

### Tested on:

  * `wasp`

### Test description:

Performed install of mentioned cray-hms-sls chart on wasp before and after issuing the new exception. The installation succeeded after the exception was issued. Before the exception, it failed as expected. 
[CASMSEC-565-wasp-cray-hms.txt](https://github.com/user-attachments/files/20455475/CASMSEC-565-wasp-cray-hms.txt)


## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

