### PR TITLE
CASMSEC-569: IUF Exceptions for node rebuilds

### DIFF
--- a/charts/kyverno-policy/Chart.yaml
+++ b/charts/kyverno-policy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kyverno-policy
-version: 1.7.12
+version: 1.7.13
 appVersion: v1.13.4
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policy/templates/exceptions/iuf-argo-exceptions.yaml
+++ b/charts/kyverno-policy/templates/exceptions/iuf-argo-exceptions.yaml
@@ -117,6 +117,7 @@ spec:
         - "*-deploy-product-*-echo-message-*"
         - "*-deploy-product-*-shell-script-*"
         - "*-update-vcs-config-*-echo-message-*"
+        - "ncn-lifecycle-rebuild-*"
         namespaces:
         - argo
   podSecurity:
@@ -124,3 +125,28 @@ spec:
       restrictedField: spec.volumes[*].hostPath
       values:
         - /var/lib/ca-certificates
+---
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: iuf-argo-bin-dir
+  namespace: {{ .Values.exceptions.namespace }}
+spec:
+  exceptions:
+  - policyName: {{ .Values.exceptions.podSecurity.baseline.policyName }}
+    ruleNames:
+    - {{ .Values.exceptions.podSecurity.baseline.ruleName }}
+  match:
+    any:
+    - resources:
+        kinds:
+        - Pod
+        names:
+        - "ncn-lifecycle-rebuild-*"
+        namespaces:
+        - argo
+  podSecurity:
+    - controlName: HostPath Volumes
+      restrictedField: spec.volumes[*].hostPath
+      values:
+        - /usr/bin


### PR DESCRIPTION
## Summary and Scope

After consulting with the IUF team, they released a list of stages and tasks in IUF workflows where hostPath volumes are expected to be used. Comparing the currently written exceptions, and the given list, it was found certain exceptions were required for the `non-lifecycle-rebuild` stage. Those exceptions are added in this PR.

## Issues and Related PRs

* Resolves [CASMSEC-569](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-569)

## Testing

### Tested on:

  * `WASP`

### Test description:

- Upgrade, Rollback Tested
[CASMSEC-569-wasp.txt](https://github.com/user-attachments/files/20574668/CASMSEC-569-wasp.txt)


## Risks and Mitigations

None


## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

