### PR TITLE
CASM-4838: Updated check-image-exceptions.yaml to modify diags exceptions

### DIFF
--- a/charts/image-verification-policy/Chart.yaml
+++ b/charts/image-verification-policy/Chart.yaml
@@ -12,4 +12,4 @@ maintainers:
 - email: security_blr@hpe.com
   name: Cray-HPE
 name: image-verification-policy
-version: 1.0.1
+version: 1.0.2

--- a/charts/image-verification-policy/templates/exceptions/check-image-exceptions.yaml
+++ b/charts/image-verification-policy/templates/exceptions/check-image-exceptions.yaml
@@ -28,9 +28,7 @@ spec:
 #diags pods exceptions
     - resources:
         names:
-        - '*badger*'
-        - '*fox*'
-        - '*cvt*'
+        - '*hms-badger-job-api*'
 
 #slurm pods exceptions
     - resources:


### PR DESCRIPTION
## Summary and Scope

In this PR, the exceptions to the diags images are modified just to exclude 'hms-badger-api' pod


## Related Jira:
https://jira-pro.it.hpe.com:8443/browse/CASM-4838

## Testing

Tested the changes by deploying the diags images

### Tested on:

  * Wasp

### Test description:

[remove-diags-exceptions-upgrade-logs.txt](https://github.com/user-attachments/files/20632342/remove-diags-exceptions-upgrade-logs.txt)
[remove-sma-exceptions-install-logs.txt](https://github.com/user-attachments/files/20632343/remove-sma-exceptions-install-logs.txt)
