### PR TITLE
feat: IUF management-node-rollout stage exceptions

### DIFF
--- a/charts/kyverno-policy/Chart.yaml
+++ b/charts/kyverno-policy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kyverno-policy
-version: 1.7.14
+version: 1.7.15
 appVersion: v1.13.4
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policy/templates/exceptions/iuf-argo-exceptions.yaml
+++ b/charts/kyverno-policy/templates/exceptions/iuf-argo-exceptions.yaml
@@ -20,6 +20,7 @@ spec:
         - "*-deploy-product-*-shell-script-*"
         - "*-deploy-product-*-echo-message-*"
         - "*-update-vcs-config-*-echo-message-*"
+        - "*-management-nodes-rollout-*-shell-script-*"
         - "*-process-media-*"
         namespaces:
         - argo
@@ -117,6 +118,7 @@ spec:
         - "*-deploy-product-*-echo-message-*"
         - "*-deploy-product-*-shell-script-*"
         - "*-update-vcs-config-*-echo-message-*"
+        - "*-management-nodes-rollout-*-shell-script-*"
         - "ncn-lifecycle-rebuild-*"
         namespaces:
         - argo


### PR DESCRIPTION
## Summary and Scope

A recent IUF run of management-node-rollout stage including rebuild and reboot stage was tested to check if further exceptions are required. It was found that two more exceptions were required for IUF. This has been added in this PR.

## Issues and Related PRs

* Resolves [CASMSEC-573](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-573)

## Testing

### Tested on:

  * `fanta`

### Test description:

- IUF stages were run and it passed the stage.
[CASMSEC-573-FANTA.txt](https://github.com/user-attachments/files/20770614/CASMSEC-573-FANTA.txt)

## Risks and Mitigations
None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

