### PR TITLE
CASMSEC-566: Modified SMA and USS exceptions

### DIFF
--- a/charts/image-verification-policy/Chart.yaml
+++ b/charts/image-verification-policy/Chart.yaml
@@ -12,4 +12,4 @@ maintainers:
 - email: security_blr@hpe.com
   name: Cray-HPE
 name: image-verification-policy
-version: 1.0.2
+version: 1.0.3

--- a/charts/image-verification-policy/templates/exceptions/check-image-exceptions.yaml
+++ b/charts/image-verification-policy/templates/exceptions/check-image-exceptions.yaml
@@ -15,36 +15,15 @@ spec:
     - check-image
   match:
     any:
-#sma pods exceptions
-    - resources:
-        names:
-        - '*sma*'
-        namespaces:
-        - 'services'
-    - resources:
-        namespaces:
-        - 'sma'
-
 #diags pods exceptions
     - resources:
         names:
         - '*hms-badger-job-api*'
-
-#slurm pods exceptions
+#uss exceptions
     - resources:
         names:
-        - '*slurm*'
-    - resources:
-        namespaces:
-        - 'user'
-    - resources:
-        selector:
-          matchLabels:
-            app.kubernetes.io/part-of: slurm
-
-#pbs pods exceptions
-    - resources:
-        names:
+        - '*slurmctld*'
+        - '*slurmdbd*'
         - '*pbs*'
 #slingshot pods exceptions
     - resources:
@@ -67,20 +46,3 @@ spec:
           matchLabels:
             prepend-registry: disable
 
-#old check-image exceptions
-    - resources:
-        names:
-        - 'munge-vault-loader-*'
-        namespaces:
-        - 'services'
-    - resources:
-        kinds:
-        - Pod
-        names:
-        - 'pbs-*'
-        - 'slurm-backup'
-        - 'slurmctld-*'
-        - 'slurmdb-*'
-        - 'slurmdbd-*'
-        namespaces:
-        - user


### PR DESCRIPTION
## Summary and Scope

Modified the check-image exceptions for sma and USS products.
* Sma exceptions are removed and tested
* USS exceptions are modified to target a few resources in which the images get mutated that fail the image verification policy


## Related Jiras:
https://jira-pro.it.hpe.com:8443/browse/CASMSEC-566
https://jira-pro.it.hpe.com:8443/browse/USS-959

## Testing

* Tested the new image-verification-policy chart during upgrade and fresh install scenarios
* Corresponding products are being tested with the exceptions changes

### Tested on:

  * `<development system>`
  * Starlord

### Test description:

[image-verification-1_0_3_fresh-install_logs.txt](https://github.com/user-attachments/files/20777092/image-verification-1_0_3_fresh-install_logs.txt)
[image-verification-1_0_3_upgrade_logs.txt](https://github.com/user-attachments/files/20777095/image-verification-1_0_3_upgrade_logs.txt)
