### PR TITLE
CASMSEC-571: replace cos-config-service exception

### DIFF
--- a/charts/kyverno-policy/Chart.yaml
+++ b/charts/kyverno-policy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kyverno-policy
-version: 1.7.15
+version: 1.7.16
 appVersion: v1.13.4
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policy/templates/exceptions/cos-config-service.yaml
+++ b/charts/kyverno-policy/templates/exceptions/cos-config-service.yaml
@@ -1,0 +1,26 @@
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: cos-config-service
+  namespace: {{ .Values.exceptions.namespace }}
+spec:
+  exceptions:
+  - policyName: {{ .Values.exceptions.podSecurity.baseline.policyName }}
+    ruleNames:
+    - {{ .Values.exceptions.podSecurity.baseline.ruleName }}
+    - autogen-{{ .Values.exceptions.podSecurity.baseline.ruleName }}
+  match:
+    any:
+    - resources:
+        kinds:
+        - Pod
+        - Deployment
+        namespaces:
+        - services
+        names:
+        - cos-config-service*
+  podSecurity:
+    - controlName: HostPath Volumes
+      restrictedField: spec.volumes[*].hostPath
+      values:
+        - /var/lib/cps-local


### PR DESCRIPTION
## Summary and Scope

A `cos-config-service` exception was removed earlier as an upcoming version of USS did not require it. To ensure backward compatibility of USS older versions with CSM 1.7, this exception is placed back again.

## Issues and Related PRs

* Resolves [CASMSEC-571](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-571)

## Testing

### Tested on:

  * `fanta`

### Test description:

- Upgrade tested, cos-config-service deployment tested.
[CASMSEC-571-COS-fanta.txt](https://github.com/user-attachments/files/20780505/CASMSEC-571-COS-fanta.txt)

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

