### PR TITLE
CASMSEC-576: velero-node-agent updated exceptions

### DIFF
--- a/charts/kyverno-policy/Chart.yaml
+++ b/charts/kyverno-policy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kyverno-policy
-version: 1.7.16
+version: 1.7.17
 appVersion: v1.13.4
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policy/templates/exceptions/velero.yaml
+++ b/charts/kyverno-policy/templates/exceptions/velero.yaml
@@ -30,3 +30,31 @@ spec:
       restrictedField: spec.initContainers[*].securityContext.privileged
       values:
         - "true"
+---
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: velero-node-agent
+  namespace: {{ .Values.exceptions.namespace }}
+spec:
+  exceptions:
+  - policyName: {{ .Values.exceptions.podSecurity.baseline.policyName }}
+    ruleNames:
+    - {{ .Values.exceptions.podSecurity.baseline.ruleName }}
+    - autogen-{{ .Values.exceptions.podSecurity.baseline.ruleName }}
+  match:
+    any:
+    - resources:
+        kinds:
+        - DaemonSet
+        - Pod
+        namespaces:
+        - velero
+        names:
+        - node-agent*
+  podSecurity:
+    - controlName: HostPath Volumes
+      restrictedField: spec.volumes[*].hostPath
+      values:
+        - /var/lib/kubelet/pods
+        - /var/lib/kubelet/plugins


### PR DESCRIPTION
## Summary and Scope

As velero updated recently, the `velero-node-agent` DaemonSet required more exceptions for hostPath volumes. This PR adds the exceptions.

## Issues and Related PRs

* Resolves [CASMSEC-576](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-576)

## Testing

### Tested on:

  * `surtur`

### Test description:

- Upgrade, Rollback Tested
- Velero Upgrade Tested
[CASMSEC-576-surtur.txt](https://github.com/user-attachments/files/20864745/CASMSEC-576-surtur.txt)

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

