### PR TITLE
CASMSEC-578: Cilium upgrade argo exceptions

### DIFF
--- a/charts/kyverno-policy/Chart.yaml
+++ b/charts/kyverno-policy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kyverno-policy
-version: 1.7.17
+version: 1.7.18
 appVersion: v1.13.4
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policy/templates/exceptions/cilium-argo-migration.yaml
+++ b/charts/kyverno-policy/templates/exceptions/cilium-argo-migration.yaml
@@ -1,0 +1,24 @@
+apiVersion: kyverno.io/v2
+kind: PolicyException
+metadata:
+  name: cilium-argo-migration
+  namespace: {{ .Values.exceptions.namespace }}
+spec:
+  exceptions:
+  - policyName: {{ .Values.exceptions.podSecurity.baseline.policyName }}
+    ruleNames:
+    - {{ .Values.exceptions.podSecurity.baseline.ruleName }}
+  match:
+    any:
+    - resources:
+        kinds:
+        - Pod
+        namespaces:
+        - argo
+        names:
+        - cilium-live-migration-*-shell-script-*
+  podSecurity:
+    - controlName: HostPath Volumes
+      restrictedField: spec.volumes[*].hostPath
+      values:
+        - /root/.ssh


### PR DESCRIPTION
## Summary and Scope

cilium upgrade through argo requires new exceptions. violations can be seen in the ticket.

## Issues and Related PRs

* Resolves [CASMSEC-578](https://jira-pro.it.hpe.com:8443/browse/CASMSEC-578)

## Testing

### Tested on:

  * `wasp`

### Test description:

- Install, Upgrade, Rollback tested
[CASMSEC-578-wasp.txt](https://github.com/user-attachments/files/20901967/CASMSEC-578-wasp.txt)

## Risks and Mitigations

None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

