### PR TITLE
CASMTRIAGE-8353: Added exceptions for unsigned USS images

### DIFF
--- a/charts/image-verification-policy/Chart.yaml
+++ b/charts/image-verification-policy/Chart.yaml
@@ -12,4 +12,4 @@ maintainers:
 - email: security_blr@hpe.com
   name: Cray-HPE
 name: image-verification-policy
-version: 1.0.3
+version: 1.0.4

--- a/charts/image-verification-policy/templates/exceptions/check-image-exceptions.yaml
+++ b/charts/image-verification-policy/templates/exceptions/check-image-exceptions.yaml
@@ -23,8 +23,9 @@ spec:
     - resources:
         names:
         - '*slurmctld*'
-        - '*slurmdbd*'
+        - '*slurmdb*'
         - '*pbs*'
+        - '*munge*'
 #slingshot pods exceptions
     - resources:
         names:


### PR DESCRIPTION
## Summary and Scope

A few USS images that are being shipped doesn't have signatures. Exceptions are added to the resources that use those images.
New exceptions:
*munge*
*slurmdb*
Removed a duplicate exception:
*slurmdbd*

## Related Jira:

https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8353
## Testing

Tested the new exceptions by upgrading and fresh installing the helm chart

### Tested on:

  * Wasp

### Test description:

[image-verification-1_0_4_install_logs.txt](https://github.com/user-attachments/files/20929082/image-verification-1_0_4_install_logs.txt)
[image-verification-1_0_4_upgrade_logs.txt](https://github.com/user-attachments/files/20929083/image-verification-1_0_4_upgrade_logs.txt)
