### PR TITLE
CASMTRIAGE-8470: Added exception for slurm-backup pod

### DIFF
--- a/charts/image-verification-policy/Chart.yaml
+++ b/charts/image-verification-policy/Chart.yaml
@@ -12,4 +12,4 @@ maintainers:
 - email: security_blr@hpe.com
   name: Cray-HPE
 name: image-verification-policy
-version: 1.0.4
+version: 1.0.5

--- a/charts/image-verification-policy/templates/exceptions/check-image-exceptions.yaml
+++ b/charts/image-verification-policy/templates/exceptions/check-image-exceptions.yaml
@@ -26,6 +26,7 @@ spec:
         - '*slurmdb*'
         - '*pbs*'
         - '*munge*'
+        - '*slurm-backup*'
 #slingshot pods exceptions
     - resources:
         names:


### PR DESCRIPTION
## Summary and Scope

An exception was added to slurm-backup pod as it was using an unsigned image.

## Related Jira

[CASMTRIAGE-8470](https://jira-pro.it.hpe.com:8443/browse/CASMTRIAGE-8470)


## Testing

Tested the upgrade and fresh install scenarios of image-verification policy with the exception
### Tested on:

  * Starlord


### Test description:
[image-verification-1_0_5_install.txt](https://github.com/user-attachments/files/21247728/image-verification-1_0_5_install.txt)
[image-verification-1_0_5_upgrade.txt](https://github.com/user-attachments/files/21247730/image-verification-1_0_5_upgrade.txt)
