### PR TITLE
CASMINST-7373: adding exception for k8s-upgrade job

### DIFF
--- a/charts/kyverno-policy/Chart.yaml
+++ b/charts/kyverno-policy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kyverno-policy
-version: 1.7.20
+version: 1.7.21
 appVersion: v1.13.4
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policy/templates/exceptions/iuf-argo-exceptions.yaml
+++ b/charts/kyverno-policy/templates/exceptions/iuf-argo-exceptions.yaml
@@ -90,6 +90,7 @@ spec:
         - "*-deploy-product-*-shell-script-*"
         - "*-management-nodes-rollout-*-shell-script-*"
         - "ncn-lifecycle-rebuild-*-shell-script-*"
+        - "upgrade-k8s-job-*"
         namespaces:
         - argo
   podSecurity:


### PR DESCRIPTION
## Summary and Scope

kubernetes upgrade is being run out of IUF stage as a separate job now. so exception is needed for the same

## Issues and Related PRs

* Resolves [CASMINST-7373](https://jira-pro.it.hpe.com:8443/browse/CASMINST-7373)
* https://github.com/Cray-HPE/docs-csm/pull/6141

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [ ] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

