### PR TITLE
CASM-5664: Add autogen rule for upgrade-k8s-job exception

### DIFF
--- a/charts/kyverno-policy/Chart.yaml
+++ b/charts/kyverno-policy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: kyverno-policy
-version: 1.7.21
+version: 1.7.22
 appVersion: v1.13.4
 description: Kubernetes Pod Security Standards implemented as Kyverno policies
 keywords:

--- a/charts/kyverno-policy/templates/exceptions/iuf-argo-exceptions.yaml
+++ b/charts/kyverno-policy/templates/exceptions/iuf-argo-exceptions.yaml
@@ -75,11 +75,13 @@ spec:
   - policyName: {{ .Values.exceptions.podSecurity.baseline.policyName }}
     ruleNames:
     - {{ .Values.exceptions.podSecurity.baseline.ruleName }}
+    - autogen-{{ .Values.exceptions.podSecurity.baseline.ruleName }}
   match:
     any:
     - resources:
         kinds:
         - Pod
+        - Job
         names:
         - "*-prepare-images-*-shell-script-*"
         - "*-process-media-*-shell-script-*"


### PR DESCRIPTION
## Summary and Scope

This adds the autogen-baseline rule for the upgrade-k8s-job-* exception for /root/.ssh.

## Issues and Related PRs

* Resolves [CASM-5664](https://jira-pro.it.hpe.com:8443/browse/CASM-5664)

## Testing

### Tested on:

  * `wasp`
[CASM-5664-wasp.txt](https://github.com/user-attachments/files/21491612/CASM-5664-wasp.txt)

### Test description:
- Upgrade tested, IUF run tested

## Risks and Mitigations
None

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [ ] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [ ] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable
- [ ] [HPC Product Announcement](https://cray.slack.com/archives/C026TVCSXLH) prepared, if applicable

